### PR TITLE
홈 - 일기 작성기 대신에 일기 뷰어로 바꾸기

### DIFF
--- a/app/actions/diary.ts
+++ b/app/actions/diary.ts
@@ -23,15 +23,18 @@ export async function createDiary(
 
   const { date, content } = validatedFields.data;
 
+  // 시간 정보 제거
+  const dateWithoutTime = removeTimeFromDate(date);
+
   if (options.temp) {
     await diary.tempSaveDiary({
       content,
-      date,
+      date: dateWithoutTime,
     });
   } else {
     await diary.createDiary({
       content,
-      date,
+      date: dateWithoutTime,
     });
   }
 

--- a/app/actions/diary.ts
+++ b/app/actions/diary.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { removeTimeFromDate } from "~/utils";
 import { revalidatePath } from "next/cache";
 
 import { diary } from "~/lib/models/diary";
@@ -57,6 +58,16 @@ export async function getDiaryById(id: string) {
 
 export async function getDiaryByDate(date: Date) {
   const data = await diary.getDiaryByDate(date);
+
+  if (!data) {
+    return null;
+  }
+
+  return data;
+}
+
+export async function getRecentDiary() {
+  const data = await diary.getRecentDiary();
 
   if (!data) {
     return null;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,19 +4,7 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@font-face {
-  font-family: "Gyeonggi_Batang_Regular";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/2410-3@1.0/Batang_Regular.woff")
-    format("woff");
-  font-weight: 400;
-  font-style: normal;
-}
-
 @theme {
-  --font-sans:
-    "Gyeonggi_Batang_Regular", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-
   @keyframes lemonwave {
     0% {
       transform: translate(-90px);

--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -9,7 +9,9 @@ export default function HomeLayout({
   return (
     <SidebarProvider>
       <AppSidebar />
-      {children}
+      <div className="w-full sm:w-3/4 md:w-3/5 xl:w-1/2 mx-auto">
+        {children}
+      </div>
     </SidebarProvider>
   );
 }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,33 +1,20 @@
-import { DiaryCard } from "~/components/diary/DiaryCard";
-import { DiaryEmpty } from "~/components/diary/DiaryEmpty";
-import { DiaryWriter } from "~/components/diary/DiaryWriter";
+import { DiaryViewer } from "~/components/diary/DiaryViewer";
 import { Header } from "~/components/Header";
-import { prisma } from "~/utils/db";
+
+import { getRecentDiary } from "../actions/diary";
 
 export default async function Home() {
-  const diarys = await prisma.diary.findMany({
-    orderBy: { createdAt: "desc" },
-  });
+  const diary = await getRecentDiary();
 
   return (
-    <div className="w-full sm:w-3/4 md:w-3/5 xl:w-1/2 mx-auto">
+    <>
       <Header>
-        <h1 className="text-2xl font-bold">일기장</h1>
+        <h1 className="text-2xl font-bold">홈</h1>
       </Header>
 
-      <div className="flex flex-col gap-4 px-6">
-        <DiaryWriter />
-
-        <hr className="my-4" />
-
-        <h2 className="text-lg font-medium">최근 일기</h2>
-
-        {diarys.length ? (
-          diarys.map((diary) => <DiaryCard diary={diary} key={diary.id} />)
-        ) : (
-          <DiaryEmpty />
-        )}
+      <div className="flex flex-col gap-4 px-6 pb-6">
+        <DiaryViewer diary={diary} />
       </div>
-    </div>
+    </>
   );
 }

--- a/app/new/layout.tsx
+++ b/app/new/layout.tsx
@@ -1,0 +1,17 @@
+import { AppSidebar } from "~/components/AppSidebar";
+import { SidebarProvider } from "~/components/ui/sidebar";
+
+export default function NewLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <div className="w-full sm:w-3/4 md:w-3/5 xl:w-1/2 mx-auto">
+        {children}
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,0 +1,16 @@
+import { DiaryWriter } from "~/components/diary/DiaryWriter";
+import { Header } from "~/components/Header";
+
+export default async function Home() {
+  return (
+    <>
+      <Header>
+        <h1 className="text-2xl font-bold">일기 쓰기</h1>
+      </Header>
+
+      <div className="flex flex-col gap-4 px-6 pb-6">
+        <DiaryWriter />
+      </div>
+    </>
+  );
+}

--- a/components/diary/DiaryCard.tsx
+++ b/components/diary/DiaryCard.tsx
@@ -1,28 +1,33 @@
+import { cn } from "~/utils";
+
 import type { Diary } from "~/lib/models/diary";
 
 interface DiaryCardProps {
   diary: Diary;
+  className?: string;
 }
 
-export function DiaryCard({ diary }: DiaryCardProps) {
+export function DiaryCard({ diary, className }: DiaryCardProps) {
   return (
-    <div className="flex flex-col gap-3 rounded-xl shadow border p-4 transition-all hover:shadow-md hover:-translate-y-1">
-      <p className="text-sm text-gray-600">
-        {diary.createdAt.toLocaleString()}
-      </p>
-
-      <p className="line-clamp-3">{diary.content}</p>
-
-      <div className="flex flex-wrap gap-2">
-        {diary.keywords.map((keyword) => (
-          <span
-            key={keyword}
-            className="bg-gray-200 text-gray-700 text-xs font-medium px-2 py-1 rounded-full"
-          >
-            {keyword}
-          </span>
-        ))}
+    <article
+      className={cn(
+        "bg-white border border-gray-300 rounded-xl shadow-md",
+        className,
+      )}
+    >
+      <div className="p-4">
+        <p
+          className="whitespace-pre-wrap break-keep-all"
+          style={{
+            backgroundImage: "linear-gradient(#ccc 1px, transparent 1px)",
+            backgroundSize: "100% 26px",
+            lineHeight: "26px",
+            backgroundPosition: "0 25px",
+          }}
+        >
+          {diary.content}
+        </p>
       </div>
-    </div>
+    </article>
   );
 }

--- a/components/diary/DiaryViewer.tsx
+++ b/components/diary/DiaryViewer.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { utcDateNow } from "~/utils";
+import { format } from "date-fns";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { getDiaryByDate } from "~/app/actions/diary";
+
+import { Spinner } from "../Spinner";
+import { DiaryCard } from "./DiaryCard";
+import { DiaryEmpty } from "./DiaryEmpty";
+
+import type { Diary } from "~/lib/models/diary";
+
+interface DiaryViewerProps {
+  diary: Diary | null;
+}
+
+export function DiaryViewer({ diary: initialDiary }: DiaryViewerProps) {
+  const [date, setDate] = useState(initialDiary?.date ?? utcDateNow);
+  const [currentDiary, setCurrentDiary] = useState<Diary | null>(
+    initialDiary || null,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [shouldLoadDiary, setShouldLoadDiary] = useState(initialDiary === null);
+
+  useEffect(() => {
+    // SSR로 첫 로딩되면 여기에 걸리고
+    if (shouldLoadDiary === false) {
+      // 다음부턴 일기 로딩하게게
+      setShouldLoadDiary(true);
+      return;
+    }
+
+    setIsLoading(true);
+    getDiaryByDate(date).then((d) => {
+      setCurrentDiary(d);
+      setIsLoading(false);
+    });
+  }, [date]);
+
+  function handlePreviousDiary() {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() - 1);
+    setDate(newDate);
+  }
+
+  function handleNextDiary() {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() + 1);
+    setDate(newDate);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="w-full flex justify-center items-center gap-4">
+        <button
+          onClick={handlePreviousDiary}
+          className="p-1 shadow rounded-md border border-gray-300 cursor-pointer"
+        >
+          <ChevronLeftIcon strokeWidth={1.5} className="size-6" />
+        </button>
+
+        <p className="text-lg font-semibold">
+          {format(date, "yyyy년 M월 d일")}
+        </p>
+        <button
+          onClick={handleNextDiary}
+          className="p-1 shadow rounded-md border border-gray-300 cursor-pointer"
+        >
+          <ChevronRightIcon strokeWidth={1.5} className="size-6" />
+        </button>
+      </div>
+      {isLoading ? (
+        <div className="flex justify-center items-center h-48">
+          <Spinner className="size-6" />
+        </div>
+      ) : currentDiary ? (
+        <DiaryCard diary={currentDiary} />
+      ) : (
+        <DiaryEmpty />
+      )}
+    </div>
+  );
+}

--- a/components/diary/DiaryWriter.tsx
+++ b/components/diary/DiaryWriter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { utcDateNow } from "~/utils";
 import { CalendarIcon, SaveIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
@@ -28,7 +29,7 @@ export function DiaryWriter() {
   const form = useForm<DiaryWriterForm>({
     resolver: zodResolver(DiaryWriterFormSchema),
     defaultValues: {
-      date: new Date(),
+      date: utcDateNow,
       content: "",
     },
   });
@@ -112,7 +113,7 @@ export function DiaryWriter() {
                 <Textarea
                   {...field}
                   disabled={isTextareaDisabled}
-                  className="shadow-md rounded-xl resize-none h-72 p-4 !text-base"
+                  className="shadow-md rounded-xl resize-none h-[500px] p-4 !text-base"
                   placeholder={
                     isTextareaDisabled
                       ? "일기를 불러오는 중입니다..."

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -12,6 +12,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       className="toaster group"
       style={
         {
+          fontFamily: "inherit",
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",

--- a/lib/models/diary/index.ts
+++ b/lib/models/diary/index.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { createEmbeddingQueue } from "~/lib/models/diary/createEmbedding";
 import { prisma } from "~/utils/db";
 
@@ -56,6 +58,16 @@ export const diary = {
     const diary = await prisma.diary.findFirst({
       where: {
         date,
+      },
+    });
+
+    return diary;
+  },
+
+  async getRecentDiary() {
+    const diary = await prisma.diary.findFirst({
+      orderBy: {
+        date: "desc",
       },
     });
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -33,3 +33,17 @@ export function safeRedirect(
 
   return to;
 }
+
+export const utcDateNow = new Date(
+  Date.UTC(
+    new Date().getFullYear(),
+    new Date().getMonth(),
+    new Date().getDate(),
+  ),
+);
+
+export function removeTimeFromDate(date: Date) {
+  return new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
+}


### PR DESCRIPTION
## 🔧 수정사항

- 폰트 두 번 로딩 안되게 global.css 수정
- sonner 컴포넌트 글꼴 적용 안되는 버그 수정
- 일기 저장 시 시간정보 들어가는 버그 수정
- 메인 페이지 레이아웃 변경, DiaryWriter 대신 DiaryViewer를 배치, 최근 일기 삭제
- 일기 쓰기 페이지 추가